### PR TITLE
Reduce replica count to 1 by default

### DIFF
--- a/charts/base/values.yaml
+++ b/charts/base/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 2
+replicaCount: 1
 
 image:
   repository: nginx


### PR DESCRIPTION
We do not need apps to run multiple replicas by default, this forces to modify the value on every setup.