### PR TITLE
Use slashes instead of dashes for secret namespacing

### DIFF
--- a/charts/base/Chart.yaml
+++ b/charts/base/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.12
+version: 0.1.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.12"
+appVersion: "0.1.13"

--- a/charts/base/README.md
+++ b/charts/base/README.md
@@ -23,6 +23,20 @@ my-app-base:
     tag: 1.2.3
 ```
 
+External secrets
+```
+my-app-base:
+  ...
+  product: my-product
+  env: production
+  secrets:
+    - secret1
+    - secret2
+    - secret3
+```
+This will produce externals ecrets which will ask secrets from store my-app-production.
+Values in Secret Manager should be put in my-product/production/my-app matching secret1, secret2, secret2.
+
 Run
 ```
 helm upgrade --install my-app .

--- a/charts/base/templates/external-secrets.yaml
+++ b/charts/base/templates/external-secrets.yaml
@@ -18,7 +18,7 @@ spec:
   {{ $property := $secret }}
   - secretKey: {{ $key }}
     remoteRef:
-      key: {{ $.Values.product }}-{{ $.Values.env }}-{{ $fullName }}
+      key: {{ $.Values.product }}/{{ $.Values.env }}/{{ $fullName }}
       property: {{ $property }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
We have decided to go with slashes when name-spacing secrets in AWS Secret Manager so chart should match the pattern.