### PR TITLE
feat(DMVP-1164): Add Weave-Scope helm chart

### DIFF
--- a/charts/weave-scope/Chart.yaml
+++ b/charts/weave-scope/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+name: weave-scope
+version: 1.0.0
+appVersion: 1.10.1
+description: A Helm chart for the Weave Scope cluster visualizer.
+keywords:
+  - containers
+  - dashboard
+  - monitoring
+home: https://www.weave.works/oss/scope/
+sources:
+  - https://github.com/weaveworks/scope
+maintainers:
+  - name: omkensey
+    email: github@orion-com.com
+icon: https://avatars1.githubusercontent.com/u/9976052?s=64

--- a/charts/weave-scope/README.md
+++ b/charts/weave-scope/README.md
@@ -1,0 +1,97 @@
+# Weave Scope
+
+## About this chart
+
+This chart contains two subcharts (*weave-scope-frontend* and *weave-scope-agent*) which deploy the corresponding components of Weave Scope, an interactive container monitoring and visualization application.
+
+Either subchart can be deployed on its own (set the "enabled" value to "false" for the chart you want to suppress) or the two can be deployed together (the default).
+
+## Compatibility notes
+
+* This chart is designed and tested with Weave Scope 1.6.2 and 1.6.5 and Kubernetes 1.7.
+* Weave Scope 1.6.2 was originally released by WeaveWorks for Kubernetes 1.6 but seems to work fine on 1.7.
+* On Kubernetes 1.6 Weave Scope versions as old as 1.3.0 will probably work.
+
+## Prerequisites
+
+* The service account, cluster role, cluster role binding and service specified in the rendered version of this chart must not already exist.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release <helm-repo>/weave-scope
+```
+
+$ helm install --name my-release stable/weave-scope
+The command deploys Weave Scope on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+
+## Configuration
+
+Note that most of this documentation is repeated in `values.yaml`; if you're in a hurry you can skip this part here and read it there.  Values with no default noted have no default.
+
+### Global values
+
+| Parameter | Description | Default |
+|----------:|:------------|:--------|
+| **image.*** | the parameters of the image pulls for this release | |
+| **image.repository** | the image that will be used for this release (required) | `weaveworks/scope` |
+| **image.tag** | the version of Weave Scope desired for this release (required) | `1.10.1`
+| **image.pullPolicy** | the imagePullPolicy for the container (required): IfNotPresent, Always, or Never | `IfNotPresent`
+| **service.*** | the configuration of the service used to access the frontend | |
+| **service.name** | the short name desired for the frontend service (optional, but if not specified by the user a value will be calculated) -- this is a global so we can access its value easily from the agent subchart | `weave-scope-app` |
+| **service.port** | the port exposed by the Scope frontend service (required if weave-scope-frontend is enabled) -- this is a global so we can access its value easily from the agent subchart | `80` |
+| **service.type** | the type of the frontend service (required if weave-scope-frontend is enabled): ClusterIP, NodePort or LoadBalancer -- this is a global to keep it with the other values for configuring the frontend service | `ClusterIP` |
+
+
+### Weave Scope frontend values
+
+The **weave-scope-frontend** section controls how the Scope frontend is installed.
+
+| Parameter | Description | Default |
+|----------:|:------------|:--------|
+| **enabled** | controls whether the frontend is deployed | `true` |
+| **resources.*** | controls requests/limits for the frontend (these values are all optional) | |
+| **resources.requests.cpu** | CPU request in MHz (m) | |
+| **resources.requests.memory** | memory request in MiB (Mi) | |
+| **resources.limits.cpu** | CPU limit in MHz (m) | |
+| **resources.limits.memory** | memory limit in MiB (Mi) | |
+
+### Weave Scope agent
+
+The **agent** section controls how the Weave Scope node agent pods are installed.
+
+| Parameter | Description | Default |
+|----------:|:------------|:--------|
+| **enabled** | controls whether the agent is deployed | `true` |
+| **dockerBridge** | the name of the Docker bridge interface | `docker0` |
+| **scopeFrontendAddr** | the host:port of a Scope frontend to send data to -- this is only needed in cases where the frontend is deployed separately from the agent (e.g. an install outside the cluster or a pre-existing install inside it) | |
+| **probeToken** | the token used to connect to Weave Cloud -- this is not needed for connecting to non-cloud Scope frontends | |
+| **rbac.*** | controls RBAC resource creation/use | |
+| **rbac.create** | whether RBAC resources should be created (required) -- this **must** be set to false if RBAC is not enabled in the cluster; it *may* be set to false in an RBAC-enabled cluster to allow for external management of RBAC | `true` |
+| **readOnly** | disables all controls (e.g. start/stop, terminal, logs, etc.) | `false` |
+| **serviceAccount.create** | whether a new service account name that the agent will use should be created. | `true` |
+| **serviceAccount.name** | service account to be used.  If not set and serviceAccount.create is `true` a name is generated using the fullname template. |  |
+| **resources.*** | controls requests/limits for the agent (these values are all optional) | |
+| **resources.requests.cpu** | CPU request in MHz (m) | |
+| **resources.requests.memory** | memory request in MiB (Mi)| |
+| **resources.limits.cpu** | CPU limit in MHz (m) | |
+| **resources.limits.memory** | memory limit in MiB (Mi) | |
+
+## Other notes
+
+* The Deployment for the frontend specifies a single replica; multiple replicas of the frontend, although they may run, probably will not work as expected since different agents may end up talking to different replicas.

--- a/charts/weave-scope/charts/weave-scope-agent/Chart.yaml
+++ b/charts/weave-scope/charts/weave-scope-agent/Chart.yaml
@@ -1,0 +1,16 @@
+description: A Helm chart for the Weave Scope cluster visualizer node agent.
+name: weave-scope-agent
+version: 0.10.0
+appVersion: 1.9.1
+keywords:
+  - containers
+  - dashboard
+  - monitoring
+home: https://www.weave.works/oss/scope/
+sources:
+  - https://github.com/weaveworks/scope
+maintainers:
+  - name: omkensey
+    email: github@orion-com.com
+icon: https://avatars1.githubusercontent.com/u/9976052?s=64
+apiVersion: v1

--- a/charts/weave-scope/charts/weave-scope-agent/templates/_helpers.tpl
+++ b/charts/weave-scope/charts/weave-scope-agent/templates/_helpers.tpl
@@ -1,0 +1,61 @@
+{{/* Helm standard labels */}}
+{{- define "weave-scope-agent.helm_std_labels" }}
+chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+heritage: {{ .Release.Service }}
+release: {{ .Release.Name }}
+app: {{ template "toplevel.name" . }}
+{{- end }}
+
+{{/* Weave Scope default annotations */}}
+{{- define "weave-scope-agent.annotations" }}
+cloud.weave.works/launcher-info: |-
+  {
+    "server-version": "master-4fe8efe",
+    "original-request": {
+      "url": "/k8s/v1.7/scope.yaml"
+    },
+    "email-address": "support@weave.works",
+    "source-app": "weave-scope",
+    "weave-cloud-component": "scope"
+  }
+{{- end }}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "weave-scope-agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Expand the name of the top-level chart.
+*/}}
+{{- define "toplevel.name" -}}
+{{- default (.Template.BasePath | split "/" )._0 .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.  We truncate at 63 chars.
+*/}}
+{{- define "weave-scope-agent.fullname" -}}
+{{- printf "%s-%s" .Chart.Name .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified name that always uses the name of the top-level chart.
+*/}}
+{{- define "toplevel.fullname" -}}
+{{- $name := default (.Template.BasePath | split "/" )._0 .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "weave-scope-agent.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "weave-scope-agent.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/weave-scope/charts/weave-scope-agent/templates/clusterrole.yaml
+++ b/charts/weave-scope/charts/weave-scope-agent/templates/clusterrole.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.enabled -}}
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "weave-scope.helm_std_labels" . | indent 4 }}
+    component: agent
+  name: {{ template "weave-scope-agent.serviceAccountName" . }} 
+  annotations:
+    {{- include "weave-scope.annotations" . | indent 4 }}
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - nonResourceURLs:
+      - '*'
+    verbs:
+      - '*'
+{{- end }}
+{{- end -}}

--- a/charts/weave-scope/charts/weave-scope-agent/templates/clusterrolebinding.yaml
+++ b/charts/weave-scope/charts/weave-scope-agent/templates/clusterrolebinding.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.enabled -}}
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "weave-scope.helm_std_labels" . | indent 4 }}
+    component: agent
+  name: {{ include "toplevel.fullname" . }}
+  annotations:
+    {{- include "weave-scope.annotations" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "weave-scope-agent.serviceAccountName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "weave-scope-agent.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end -}}

--- a/charts/weave-scope/charts/weave-scope-agent/templates/daemonset.yaml
+++ b/charts/weave-scope/charts/weave-scope-agent/templates/daemonset.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.enabled -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    {{- include "weave-scope-agent.helm_std_labels" . | indent 4 }}
+    component: agent
+  name: {{ template "weave-scope-agent.fullname" . }}
+  annotations:
+    {{- include "weave-scope-agent.annotations" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "toplevel.name" . }}
+      release: {{ .Release.Name }}
+      component: agent
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        {{- include "weave-scope-agent.helm_std_labels" . | indent 8 }}
+        component: agent
+    spec:
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+      containers:
+        - name: {{ template "weave-scope-agent.name" . }}
+          image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"
+          imagePullPolicy: "{{ .Values.global.image.pullPolicy }}"
+          args:
+            - '--no-app'
+            - '--probe.docker.bridge={{ .Values.dockerBridge }}'
+            - '--probe.docker=true'
+            - '--probe.kubernetes=true'
+            {{if .Values.readOnly}}
+            - "--probe.no-controls"
+            {{end}}
+            {{- if .Values.global.probeToken }}
+            - '--probe-token={{ .Values.global.probeToken }}'
+            {{- else if .Values.global.scopeFrontendAddr }}
+            - {{ .Values.global.scopeFrontendAddr }}
+            {{- else }}
+            - {{ .Values.global.service.name | default (include "toplevel.fullname" .) }}.{{ .Release.Namespace }}.svc:{{ .Values.global.service.port }}
+            {{- end }}
+          securityContext:
+            privileged: true
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          volumeMounts:
+            - name: docker-socket
+              mountPath: /var/run/docker.sock
+            - name: scope-plugins
+              mountPath: /var/run/scope/plugins
+            - name: sys-kernel-debug
+              mountPath: /sys/kernel/debug
+      volumes:
+        - name: docker-socket
+          hostPath:
+            path: /var/run/docker.sock
+        - name: scope-plugins
+          hostPath:
+            path: /var/run/scope/plugins
+        - name: sys-kernel-debug
+          hostPath:
+            path: /sys/kernel/debug
+      hostPID: true
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccountName: {{ template "weave-scope-agent.serviceAccountName" . }}
+{{- end -}}

--- a/charts/weave-scope/charts/weave-scope-agent/templates/serviceaccount.yaml
+++ b/charts/weave-scope/charts/weave-scope-agent/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.enabled -}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "weave-scope.helm_std_labels" . | indent 4 }}
+    component: agent
+  name: {{ template "weave-scope-agent.serviceAccountName" . }}
+  annotations:
+    {{- include "weave-scope.annotations" . | indent 4 }}
+{{- end }}
+{{- end -}}

--- a/charts/weave-scope/charts/weave-scope-frontend/Chart.yaml
+++ b/charts/weave-scope/charts/weave-scope-frontend/Chart.yaml
@@ -1,0 +1,16 @@
+description: A Helm chart for the Weave Scope cluster visualizer frontend.
+name: weave-scope-frontend
+version: 0.10.0
+appVersion: 1.9.1
+keywords:
+  - containers
+  - dashboard
+  - monitoring
+home: https://www.weave.works/oss/scope/
+sources:
+  - https://github.com/weaveworks/scope
+maintainers:
+  - name: omkensey
+    email: github@orion-com.com
+icon: https://avatars1.githubusercontent.com/u/9976052?s=64
+apiVersion: v1

--- a/charts/weave-scope/charts/weave-scope-frontend/templates/_helpers.tpl
+++ b/charts/weave-scope/charts/weave-scope-frontend/templates/_helpers.tpl
@@ -1,0 +1,50 @@
+{{/* Helm standard labels */}}
+{{- define "weave-scope-frontend.helm_std_labels" }}
+chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+heritage: {{ .Release.Service }}
+release: {{ .Release.Name }}
+app: {{ template "toplevel.name" . }}
+{{- end }}
+
+{{/* Weave Scope default annotations */}}
+{{- define "weave-scope-frontend.annotations" }}
+cloud.weave.works/launcher-info: |-
+  {
+    "server-version": "master-4fe8efe",
+    "original-request": {
+      "url": "/k8s/v1.7/scope.yaml"
+    },
+    "email-address": "support@weave.works",
+    "source-app": "weave-scope",
+    "weave-cloud-component": "scope"
+  }
+{{- end }}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "weave-scope-frontend.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Expand the name of the top-level chart.
+*/}}
+{{- define "toplevel.name" -}}
+{{- default (.Template.BasePath | split "/" )._0 .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.  We truncate at 63 chars.
+*/}}
+{{- define "weave-scope-frontend.fullname" -}}
+{{- printf "%s-%s" .Chart.Name .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified name that always uses the name of the top-level chart.
+*/}}
+{{- define "toplevel.fullname" -}}
+{{- $name := default (.Template.BasePath | split "/" )._0 .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/weave-scope/charts/weave-scope-frontend/templates/deployment.yaml
+++ b/charts/weave-scope/charts/weave-scope-frontend/templates/deployment.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    {{- include "weave-scope-frontend.helm_std_labels" . | indent 4 }}
+    component: frontend
+  name: {{ template "weave-scope-frontend.fullname" . }}
+  annotations:
+    {{- include "weave-scope.annotations" . | indent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "toplevel.name" . }}
+      release: {{ .Release.Name }}
+      component: frontend
+  template:
+    metadata:
+      labels:
+        {{- include "weave-scope-frontend.helm_std_labels" . | indent 8 }}
+        component: frontend
+    spec:
+      containers:
+        - name: {{ template "weave-scope-frontend.name" . }}
+          image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"
+          imagePullPolicy: "{{ .Values.global.image.pullPolicy }}"
+          args:
+            - "--no-probe"
+          ports:
+            - name: http
+              containerPort: 4040
+              protocol: TCP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+{{- end -}}

--- a/charts/weave-scope/charts/weave-scope-frontend/templates/service.yaml
+++ b/charts/weave-scope/charts/weave-scope-frontend/templates/service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{- include "weave-scope-frontend.helm_std_labels" . | indent 4 }}
+    component: frontend
+  name: {{ .Values.global.service.name | default (include "toplevel.fullname" .) }}
+  annotations:
+    {{- include "weave-scope-frontend.annotations" . | indent 4 }}
+spec:
+  ports:
+    - name: http
+      port: {{ .Values.global.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    app: {{ template "toplevel.name" . }}
+    release: {{ .Release.Name }}
+    component: frontend
+  type: {{ .Values.global.service.type }}
+{{- end -}}

--- a/charts/weave-scope/templates/NOTES.txt
+++ b/charts/weave-scope/templates/NOTES.txt
@@ -1,0 +1,34 @@
+{{- $agent := index .Values "weave-scope-agent" -}}
+You should now be able to access the Scope frontend in your web browser, by 
+{{- if $agent.probeToken }}
+logging into https://cloud.weave.works/ with your credentials.
+{{- else if $agent.scopeFrontend }} going to http://{{ $agent.scopeFrontend }}.
+{{- else if eq .Values.global.service.type "LoadBalancer" }}
+going to the URL given by:
+
+kubectl -n {{ .Release.Namespace }} get svc {{ .Values.global.service.name | default (include "toplevel.fullname" .) }} \
+-o jsonpath='http://{.status.loadBalancer.ingress[0].hostname}:{{ .Values.global.service.port }}/{"\n"}'
+{{- else if eq .Values.global.service.type "NodePort" }}
+going to the address or hostname of any node in the cluster, using http 
+and the port given by:
+
+SCOPE_PORT=$(kubectl -n {{ .Release.Namespace }} get svc {{ .Values.global.service.name | default (include "toplevel.fullname" .) }} \
+-o jsonpath='{.spec.ports[?(@.name==http)].nodePort}'); echo $SCOPE_PORT
+
+Most likely one or more of the URLs given by this pipeline will work:
+
+SCOPE_PORT=$(kubectl -n {{ .Release.Namespace }} get svc {{ .Values.global.service.name }} \
+-o jsonpath='{.spec.ports[?(@.name==http)].nodePort}'); \
+kubectl get nodes -o jsonpath='{.items[0].status.addresses[*].address}' | \
+xargs -I{} -d" " echo http://{}:$SCOPE_PORT 
+{{- else }}
+using kubectl port-forward:
+
+kubectl -n {{ .Release.Namespace }} port-forward $(kubectl -n {{ .Release.Namespace }} get endpoints \
+{{ .Values.global.service.name | default (include "toplevel.fullname" .) }} -o jsonpath='{.subsets[0].addresses[0].targetRef.name}') 8080:4040
+
+then browsing to http://localhost:8080/.
+{{- end }}
+For more details on using Weave Scope, see the Weave Scope documentation:
+
+https://www.weave.works/docs/scope/latest/introducing/

--- a/charts/weave-scope/templates/_helpers.tpl
+++ b/charts/weave-scope/templates/_helpers.tpl
@@ -1,0 +1,50 @@
+{{/* Helm standard labels */}}
+{{- define "weave-scope.helm_std_labels" }}
+chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+heritage: {{ .Release.Service }}
+release: {{ .Release.Name }}
+app: {{ template "toplevel.name" . }}
+{{- end }}
+
+{{/* Weave Scope default annotations */}}
+{{- define "weave-scope.annotations" }}
+cloud.weave.works/launcher-info: |-
+  {
+    "server-version": "master-4fe8efe",
+    "original-request": {
+      "url": "/k8s/v1.7/scope.yaml"
+    },
+    "email-address": "support@weave.works",
+    "source-app": "weave-scope",
+    "weave-cloud-component": "scope"
+  }
+{{- end }}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "weave-scope.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Expand the name of the top-level chart.
+*/}}
+{{- define "toplevel.name" -}}
+{{- default (.Template.BasePath | split "/" )._0 .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.  We truncate at 63 chars.
+*/}}
+{{- define "weave-scope.fullname" -}}
+{{- printf "%s-%s" .Chart.Name .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified name that always uses the name of the top-level chart.
+*/}}
+{{- define "toplevel.fullname" -}}
+{{- $name := default (.Template.BasePath | split "/" )._0 .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/weave-scope/templates/test-config.yaml
+++ b/charts/weave-scope/templates/test-config.yaml
@@ -1,0 +1,18 @@
+{{- $frontend := index .Values "weave-scope-frontend" -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "weave-scope.fullname" . }}-tests
+  labels:
+    {{- include "weave-scope.helm_std_labels" . | indent 4 }}
+data:
+  run.sh: |-
+{{ if $frontend.enabled }}
+    @test "Testing Weave Scope UI is accessible" {
+      curl --retry 12 --retry-delay 10 http://{{ .Values.global.service.name | default (include "toplevel.fullname" .) }}.{{ .Release.Namespace }}.svc:{{ .Values.global.service.port }}
+    }
+{{- else }}
+    @test "Null test if the frontend is not installed" {
+      true
+    }
+{{- end }}

--- a/charts/weave-scope/templates/weave-scope-tests.yaml
+++ b/charts/weave-scope/templates/weave-scope-tests.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-ui-test-{{ randAlphaNum 5 | lower }}"
+  annotations:
+    "helm.sh/hook": test-success
+  labels:
+    {{- include "weave-scope.helm_std_labels" . | indent 4 }}
+spec:
+  initContainers:
+    - name: "test-framework"
+      image: "dduportal/bats:0.4.0"
+      command:
+      - "bash"
+      - "-c"
+      - |
+        set -ex
+        # copy bats to tools dir
+        cp -R /usr/local/libexec/ /tools/bats/
+      volumeMounts:
+      - mountPath: /tools
+        name: tools
+  containers:
+    - name: {{ .Release.Name }}-ui-test
+      image: dduportal/bats:0.4.0
+      command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
+      volumeMounts:
+      - mountPath: /tests
+        name: tests
+        readOnly: true
+      - mountPath: /tools
+        name: tools
+  volumes:
+  - name: tests
+    configMap:
+      name: {{ template "weave-scope.fullname" . }}-tests
+  - name: tools
+    emptyDir: {}
+  restartPolicy: Never

--- a/charts/weave-scope/values.yaml
+++ b/charts/weave-scope/values.yaml
@@ -1,0 +1,77 @@
+# Where defaults exist, the values are set to them here.
+# Values with no preferred or common defaults are set to empty strings.
+global:
+  # global.image: the image that will be used for this release
+  image:
+    repository: weaveworks/scope
+    tag: 1.10.1
+    # global.image.pullPolicy: must be Always, IfNotPresent, or Never
+    pullPolicy: "IfNotPresent"
+  # global.service.*: the configuration of the service used to access the frontend
+  service:
+    # global.service.name: the short name desired for the frontend service
+    # global.service.name may be specified if you need to use a specific service name, but will be generated if not specified
+    # global.service.name is a global so we can access its value easily from the agent subchart
+    # name: "weave-scope-app"
+    # global.service.port: (required if frontend.enabled == true) the port exposed by the Scope frontend service
+    # global.service.port is a global so we can access its value easily from the agent subchart
+    port: 80
+    # global.service.type: (required if frontend.enabled == true) the type of the frontend service -- must be ClusterIP, NodePort or LoadBalancer
+    # global.service.type is a global to keep it with the other values for configuring the frontend service
+    type: "ClusterIP"
+
+# weave-scope-frontend.* controls how the Scope frontend is installed
+weave-scope-frontend:
+  enabled: true
+    # weave-scope-frontend.resources.*: controls requests/limits for the frontend
+    # weave-scope-frontend.resources.* values are all optional but should not be set to empty values
+    # resources:
+      # requests:
+        # weave-scope-frontend.resources.requests.cpu: CPU req. in MHz (m)
+        # cpu: ""
+        # weave-scope-frontend.resources.requests.memory: memory req. in MiB (Mi)
+        # memory: ""
+      # limits:
+        # weave-scope-frontend.resources.limits.cpu: CPU limit in MHz (m)
+        # cpu: ""
+        # weave-scope-frontend.resources.limits.memory: memory limit in MiB (Mi)
+        # memory: ""
+
+# weave-scope-agent.* controls how the Weave Scope node agent pods are installed
+weave-scope-agent:
+  enabled: true
+  # weave-scope-agent.dockerBridge: (required if agent.enabled == true) the name of the Docker bridge interface
+  dockerBridge: "docker0"
+  # weave-scope-agent.scopeFrontendAddr: the host:port of a Scope frontend to send data to
+  # weave-scope-agent.scopeFrontendAddr is only needed for some cases where the frontend is deployed separately from the agent
+  scopeFrontendAddr: ""
+  # weave-scope-agent.probeToken: the token used to connect to Weave Cloud
+  # weave-scope-agent.probeToken is not needed for connecting to non-cloud Scope frontends
+  probeToken: ""
+  # weave-scope-agent.rbac.*: controls RBAC resource creation/use
+  rbac:
+    # weave-scope-agent.rbac.create: whether RBAC resources should be created
+    # weave-scope-agent.rbac.create *must* be set to false if RBAC is not enabled in the cluster
+    # weave-scope-agent.rbac.create *may* be set to false in an RBAC-enabled cluster to allow for external management of RBAC
+    create: true
+  # Enabling readOnly adds --probe.no-controls to args list.
+  readOnly: false
+  serviceAccount:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.
+    # If not set and create is true, a name is generated using the fullname template
+    # name: "weave-scope"
+  # weave-scope-agent.resources.*: controls requests/limits for the agent
+  # weave-scope-agent.resources.* values are all optional but should not be set to empty values
+  # resources:
+    # requests:
+      # weave-scope-agent.resources.requests.cpu: CPU req. in MHz (m)
+      # cpu: ""
+      # weave-scope-agent.resources.requests.memory: memory req. in MiB (Mi)
+      # memory: ""
+    # limits:
+      # weave-scope-agent.resources.limits.cpu: CPU limit in MHz (m)
+      # cpu: ""
+      # weave-scope-agent.resources.limits.memory: memory limit in MiB (Mi)
+      # memory: ""


### PR DESCRIPTION
This helm chart is used to provision Weave-scope on Kubernetes Cluster, Its is up-to-date with latest Kubernetes versions