### PR TITLE
fix(DMVP-1241): Fixed bugs in mongodb-bi-connector chart.

### DIFF
--- a/charts/mongodb-bi-connector/Chart.yaml
+++ b/charts/mongodb-bi-connector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mongodb-bi-connector/Dockerfile
+++ b/charts/mongodb-bi-connector/Dockerfile
@@ -24,4 +24,4 @@ COPY ./certs /home/mongobi/mongodb-bi-linux-x86_64-ubuntu1804-v2.14.5/certs
 
 EXPOSE 3307
 
-CMD ["mongosqld", "--config=/home/mongobi/mongodb-bi-linux-x86_64-ubuntu1804-v2.14.5/example-mongosqld-config.yml"]
+CMD ["mongosqld", "--config=/home/mongobi/mongodb-bi-linux-x86_64-ubuntu1804-v2.14.5/mongosqld/config.yaml"]

--- a/charts/mongodb-bi-connector/README.md
+++ b/charts/mongodb-bi-connector/README.md
@@ -10,7 +10,7 @@ The BI Connector includes a ConfigMap that stores the configuration for the BI C
 ...
 dependencies:
 - name: mongodb-bi-connector
-  version: 0.1.0
+  version: 1.0.0
   repository: https://dasmeta.github.io/helm
 ...
 ```

--- a/charts/mongodb-bi-connector/values.yaml
+++ b/charts/mongodb-bi-connector/values.yaml
@@ -12,12 +12,6 @@ base:
     type: ClusterIP
     port: 3307
 
-  command:
-    - "/bin/bash"
-    - "-c"
-    - "mongosqld --config /home/mongobi/mongodb-bi-linux-x86_64-ubuntu1804-v2.14.5/mongosqld/config.yaml --logPath=/home/mongobi/mongodb-bi-linux-x86_64-ubuntu1804-v2.14.5/log/sqld.log"
-    - "service rsyslog start"
-
   deployment:
     volumes:
       - mountPath: /home/mongobi/mongodb-bi-linux-x86_64-ubuntu1804-v2.14.5/mongosqld
@@ -45,10 +39,6 @@ mongosqldConfigDefault:
     logRotate: "rename"
   schema:
     refreshIntervalSecs: 0
-    stored:
-      mode: "custom"
-      source: "mongosqld_data"
-      name: "mySchema"
     sample:
       size: 1000
       namespaces: ["*.*"]


### PR DESCRIPTION
1. Fixed Dockerfile CMD config.
2. Deleted not used config from values.yaml.
3. Updated chart version to 1.0.0.