### PR TITLE
fix(DMVP-9224): support templates in hostname(and not only) variables of gateway api common htproute/istio-envoyfilter/istio-authorizationpolicy configs

### DIFF
--- a/charts/gateway-api/Chart.yaml
+++ b/charts/gateway-api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gateway-api/README.md
+++ b/charts/gateway-api/README.md
@@ -28,7 +28,7 @@ You can either set `gateways[].infrastructure.parametersRef` to reference an exi
 | `httpRoutes` | List of HTTPRoute resources | `[]`; see suboptions below |
 | `httpRoutes[].name`, `nameSuffix` | Route name and optional suffix for the resource name | e.g. name: main, nameSuffix: -route |
 | `httpRoutes[].parentRefs` | Gateway parent refs (name, sectionName, kind, group); optional if defaultParentRefs set | name: main, sectionName: http |
-| `httpRoutes[].hostnames` | Hostnames this route matches | e.g. example.com |
+| `httpRoutes[].hostnames` | Hostnames this route matches. Supports templated expressions via Helm `tpl`. | e.g. `{{ .Values.global.environment }}.example.com` |
 | `httpRoutes[].rules` | Route rules: `matches` (path, headers), `backendRefs`, `filters` (e.g. RequestRedirect), `directResponse` | PathPrefix /, backendRefs to service |
 | `httpRoutes[].rules[].directResponse.status` | Direct response status. `403` keeps AuthorizationPolicy flow; non-`403` statuses are rendered via Istio EnvoyFilter | `403` or `200-599` |
 | `httpRoutes[].rules[].directResponse.body` | Optional response body for non-`403` direct responses | `""` (empty string) |
@@ -39,7 +39,13 @@ You can either set `gateways[].infrastructure.parametersRef` to reference an exi
 | `istio` | Istio-specific CRDs (when using Istio as Gateway implementation) | see suboptions below |
 | `istio.defaultTargetRefs` | Default targetRefs for AuthorizationPolicy | `[]` |
 | `istio.gateways` | List of Istio Gateway resources (networking.istio.io; for VirtualService) | selector, servers |
-| `istio.authorizationPolicies` | List of AuthorizationPolicy (allow/deny by path, host, IP) | action DENY/ALLOW, rules |
+| `istio.authorizationPolicies` | List of AuthorizationPolicy (allow/deny by path, host, IP). `rules` supports templated expressions via Helm `tpl`. | action DENY/ALLOW, rules |
 | `istio.peerAuthentications` | List of PeerAuthentication (mTLS) | mode STRICT/PERMISSIVE |
 | `istio.virtualServices` | List of VirtualService resources | hosts, http match/route |
 | `istio.sidecars` | List of Sidecar resources | `[]` |
+
+### Templating support notes
+
+- `httpRoutes[].hostnames` values are rendered with Helm `tpl`.
+- `istio.authorizationPolicies[].rules` values are rendered with Helm `tpl`.
+- Generated EnvoyFilter `configPatches` are rendered with Helm `tpl`, so templates that resolve through route hostnames and related values propagate correctly.

--- a/charts/gateway-api/templates/httproute.yaml
+++ b/charts/gateway-api/templates/httproute.yaml
@@ -48,7 +48,7 @@ spec:
     {{- end }}
   {{- end }}
   {{- if $hostnames }}
-  hostnames: {{- toYaml $hostnames | nindent 2 }}
+  hostnames: {{- tpl (toYaml $hostnames) $outer | nindent 2 }}
   {{- end }}
   {{- if $allRules }}
   rules:

--- a/charts/gateway-api/templates/istio/authorizationpolicy.yaml
+++ b/charts/gateway-api/templates/istio/authorizationpolicy.yaml
@@ -104,7 +104,7 @@ spec:
     {{- end }}
   {{- end }}
   {{- with $policy.rules }}
-  rules: {{- toYaml . | nindent 2 }}
+  rules: {{- tpl (toYaml .) $outer | nindent 2 }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/gateway-api/templates/istio/envoyfilter.yaml
+++ b/charts/gateway-api/templates/istio/envoyfilter.yaml
@@ -99,6 +99,6 @@ spec:
     {{- end }}
   {{- end }}
   configPatches:
-    {{- toYaml $filter.configPatches | nindent 4 }}
+    {{- tpl (toYaml $filter.configPatches) $outer | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/examples/gateway-api/with-template-hostname.yaml
+++ b/examples/gateway-api/with-template-hostname.yaml
@@ -1,11 +1,14 @@
 # helm diff upgrade --install -n istio-system gateway-api-direct-response ./charts/gateway-api -f ./examples/gateway-api/with-istio-envoyfilter-direct-response.yaml
+global:
+  environment: dev
 httpRoutes:
   - name: direct-response
     parentRefs:
       - name: main
         sectionName: http-echo-gw-http
     hostnames:
-      - http-echo-gw.localhost
+      - "{{ .Values.global.environment }}.http-echo-gw.localhost"
+      # - "http-echo-gw.localhost"
     rules:
       - matches:
           - path:

--- a/examples/gateway-api/with-template-hostname.yaml
+++ b/examples/gateway-api/with-template-hostname.yaml
@@ -1,9 +1,8 @@
-# helm diff upgrade --install -n istio-system gateway-api-direct-response ./charts/gateway-api -f ./examples/gateway-api/with-istio-envoyfilter-direct-response.yaml
+# helm diff upgrade --install -n istio-system with-template-hostname ./charts/gateway-api -f ./examples/gateway-api/with-template-hostname.yaml
 global:
   environment: dev
 httpRoutes:
-  - name: direct-response
-    parentRefs:
+  - parentRefs:
       - name: main
         sectionName: http-echo-gw-http
     hostnames:

--- a/specs/011-gateway-tpl-support/checklists/requirements.md
+++ b/specs/011-gateway-tpl-support/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Gateway API tpl Support
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-14  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation pass 1: all checklist items passed; no additional revisions required.

--- a/specs/011-gateway-tpl-support/contracts/render-contract.md
+++ b/specs/011-gateway-tpl-support/contracts/render-contract.md
@@ -1,0 +1,37 @@
+# Render Contract: Gateway API tpl Support
+
+## Contract Type
+
+Helm chart render contract (values input to manifest output).
+
+## Inputs
+
+- Chart: `./charts/gateway-api`
+- Values files (including examples) providing:
+  - HTTPRoute `hostnames`
+  - AuthorizationPolicy `rules`
+  - EnvoyFilter `configPatches`
+- Template context values referenced by expressions.
+
+## Output Guarantees
+
+When input templates resolve successfully:
+
+1. HTTPRoute manifests include resolved `hostnames`.
+2. AuthorizationPolicy manifests include resolved `rules`.
+3. EnvoyFilter manifests include resolved `configPatches`.
+4. Rendered manifests remain valid YAML and structurally valid for their target fields.
+5. Static-value behavior remains unchanged.
+
+## Failure Semantics
+
+When template expressions reference missing or invalid context:
+
+- Rendering fails during `helm template`.
+- Failure is explicit and blocks successful output generation.
+
+## Verification Signals
+
+- `helm lint ./charts/gateway-api` passes.
+- `helm template` passes for updated tpl example.
+- `helm template` passes for at least one existing related example to confirm no regression.

--- a/specs/011-gateway-tpl-support/data-model.md
+++ b/specs/011-gateway-tpl-support/data-model.md
@@ -1,0 +1,43 @@
+# Data Model: Gateway API tpl Support
+
+## Entity: Route Hostname Configuration
+
+- **Source**: Chart values under HTTPRoute configuration.
+- **Type**: Ordered list of hostname entries.
+- **Allowed content**:
+  - Static hostnames.
+  - Template expressions resolving to hostnames.
+- **Validation rules**:
+  - Must resolve into YAML list format accepted by HTTPRoute hostnames.
+  - Rendered output must remain valid YAML.
+
+## Entity: Authorization Rule Configuration
+
+- **Source**: Chart values under Istio AuthorizationPolicy configuration.
+- **Type**: List/object structure matching policy rules schema.
+- **Allowed content**:
+  - Static rule objects.
+  - Template expressions resolving to rule objects or lists.
+- **Validation rules**:
+  - Must resolve into valid policy rules structure.
+  - Missing referenced template values cause render-time failure.
+
+## Entity: Envoy Filter Patch Configuration
+
+- **Source**: Chart values under Istio EnvoyFilter configuration.
+- **Type**: List of filter patch objects.
+- **Allowed content**:
+  - Static patch objects.
+  - Template expressions resolving to one or more patch objects.
+- **Validation rules**:
+  - Must resolve into valid `configPatches` array content.
+  - Rendered output must preserve indentation and structure.
+
+## Entity: Rendered Manifest Output
+
+- **Produced by**: `helm template` over chart + values.
+- **Consumers**: Operators applying manifests to Kubernetes.
+- **Quality constraints**:
+  - Valid YAML document structure.
+  - Correct field placement in HTTPRoute, AuthorizationPolicy, EnvoyFilter objects.
+  - No behavior regression for static-only values.

--- a/specs/011-gateway-tpl-support/plan.md
+++ b/specs/011-gateway-tpl-support/plan.md
@@ -1,0 +1,96 @@
+# Implementation Plan: Gateway API tpl Support
+
+**Branch**: `011-gateway-tpl-support` | **Date**: 2026-04-14 | **Spec**: `/specs/011-gateway-tpl-support/spec.md`  
+**Input**: Feature specification from `/specs/011-gateway-tpl-support/spec.md`
+
+## Summary
+
+Add templating support parity for Gateway API and Istio sections by allowing resolved template expressions in HTTPRoute hostnames, AuthorizationPolicy rules, and EnvoyFilter config patches. Deliver the change with chart/example validation, no regression to static values, and updated examples/documentation that show end-user usage.
+
+## Technical Context
+
+**Language/Version**: Helm template DSL (Go templates via `tpl`), YAML manifests  
+**Primary Dependencies**: Helm 3 CLI, Gateway API resources, Istio resources, chart values schema  
+**Storage**: N/A (render-time configuration only)  
+**Testing**: `helm lint`, `helm template` for changed/new examples, regression templates for existing examples  
+**Target Platform**: Kubernetes clusters consuming rendered Helm manifests  
+**Project Type**: Helm chart repository  
+**Performance Goals**: Render succeeds for all affected examples in a single run without manual post-processing  
+**Constraints**: Preserve existing static behavior; maintain valid YAML indentation and object structure; keep chart consumer-facing values contract stable  
+**Scale/Scope**: One chart (`gateway-api`) with related base chart dependency and examples/docs updates
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] **Chart-First**: Work remains within existing Helm charts under `charts/`.
+- [x] **Values Contract**: New behavior is template evaluation of user-provided values; no environment hardcoding introduced.
+- [x] **Lint & Template**: Plan includes mandatory `helm lint` and `helm template` validation for changed chart and examples.
+- [x] **Examples for new abilities**: Plan includes updates to `examples/gateway-api/` and regression checks for existing examples.
+- [x] **Example testing and regression**: Plan includes rendering updated example and additional existing examples.
+- [x] **Official documentation before implementation**: Plan includes validation against Gateway API and Istio field expectations for target sections.
+- [x] **Versioning & compatibility**: Plan includes chart version bump for modified charts before completion.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/011-gateway-tpl-support/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── render-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+charts/
+├── gateway-api/
+│   ├── Chart.yaml
+│   └── templates/
+│       ├── httproute.yaml
+│       └── istio/
+│           ├── authorizationpolicy.yaml
+│           └── envoyfilter.yaml
+└── base/
+    └── Chart.yaml
+
+examples/
+├── gateway-api/
+│   └── with-istio-envoyfilter-direct-response.yaml
+└── base/
+    └── with-istio-gateway-api-http-route-only.yaml
+```
+
+**Structure Decision**: Keep all changes inside existing chart templates, chart metadata versions, and example values files. No new runtime components are introduced.
+
+## Phase 0: Research Plan
+
+- Confirm render behavior and indentation guarantees when using `tpl (toYaml ...)` in list/object fields.
+- Confirm expected field shapes for:
+  - HTTPRoute `hostnames`
+  - AuthorizationPolicy `rules`
+  - EnvoyFilter `configPatches`
+- Confirm validation commands and representative examples for non-regression coverage.
+
+## Phase 1: Design & Contracts Plan
+
+- Document value entities and render transformations in `data-model.md`.
+- Define render-time contract (inputs, outputs, and failure semantics) in `contracts/render-contract.md`.
+- Provide operator execution and verification flow in `quickstart.md`.
+- Re-check constitution compliance after artifact generation.
+
+## Post-Design Constitution Check
+
+- [x] No constitution violations introduced by planned approach.
+- [x] Plan explicitly includes example updates and regression rendering.
+- [x] Plan explicitly includes chart version bump expectations.
+
+## Complexity Tracking
+
+No constitution violations requiring justification.

--- a/specs/011-gateway-tpl-support/quickstart.md
+++ b/specs/011-gateway-tpl-support/quickstart.md
@@ -1,0 +1,46 @@
+# Quickstart: Gateway API tpl Support
+
+## 1) Validate chart syntax
+
+Run from repository root:
+
+`helm lint ./charts/gateway-api`
+
+## 2) Render updated tpl example
+
+Run from repository root:
+
+`helm template gateway ./charts/gateway-api -f ./examples/gateway-api/with-istio-envoyfilter-direct-response.yaml`
+
+Expected:
+
+- Render succeeds without template errors.
+- HTTPRoute hostnames are resolved in output.
+- AuthorizationPolicy rules are resolved in output (including user-provided templated `istio.authorizationPolicies[].rules`).
+- EnvoyFilter config patches are resolved in output (generated from route rules and resolved hostnames).
+- Output contains the resolved hostname string (for example, `dev.http-echo-gw.localhost` when `global.environment=dev`).
+
+## 3) Run regression example renders
+
+Run from repository root:
+
+`helm template base ./charts/base -f ./examples/base/with-istio-gateway-api-http-route-only.yaml`
+
+Expected:
+
+- Existing static-value example still renders successfully.
+- No regressions in unaffected resources.
+
+## 4) Verify docs/examples updates
+
+- Ensure updated examples include runnable command comment at the top.
+- Ensure chart documentation describes tpl support for target fields.
+- Confirm README guidance explicitly calls out:
+  - `httpRoutes[].hostnames`
+  - `istio.authorizationPolicies[].rules`
+  - generated EnvoyFilter `configPatches`
+
+## 5) Final release hygiene
+
+- Bump chart version(s) for modified chart(s) in `Chart.yaml`.
+- Re-run lint and template commands after version bump.

--- a/specs/011-gateway-tpl-support/research.md
+++ b/specs/011-gateway-tpl-support/research.md
@@ -1,0 +1,44 @@
+# Research: Gateway API tpl Support
+
+## Decision 1: Apply templating at serialized block level for target fields
+
+- **Decision**: Use `tpl (toYaml <value>) $outer | nindent <N>` for `hostnames`, `rules`, and `configPatches`.
+- **Rationale**: This keeps behavior consistent across list/object payloads, preserves existing values structure expectations, and supports mixed static/template content.
+- **Alternatives considered**:
+  - Per-item templating loops for each field: rejected due to duplicated template logic and higher indentation risk.
+  - No templating for policy/filter blocks: rejected because it fails feature parity and user request.
+
+## Decision 2: Keep rendering failures explicit for unresolved template references
+
+- **Decision**: Preserve Helm default behavior where unresolved template expressions fail during render.
+- **Rationale**: Explicit render failure is safer than silently producing malformed or unexpected manifests.
+- **Alternatives considered**:
+  - Swallow errors and render empty output: rejected because it masks configuration issues.
+  - Custom fallback defaults in templates: rejected due to ambiguous behavior and hidden coupling to values.
+
+## Decision 3: Validate with lint + targeted and regression example templates
+
+- **Decision**: Require `helm lint` on affected chart(s), `helm template` on updated example(s), and `helm template` on additional existing examples for regression.
+- **Rationale**: Aligns with repository constitution and catches YAML/templating regressions before release.
+- **Alternatives considered**:
+  - Validate only updated example: rejected because regressions can affect unchanged examples.
+  - Validate only chart defaults: rejected because the feature specifically targets advanced values paths.
+
+## Decision 4: Document as consumer-facing configuration capability
+
+- **Decision**: Update example files and chart docs to explicitly state templating support in the three target fields.
+- **Rationale**: The change introduces a new consumer-visible behavior and must be discoverable.
+- **Alternatives considered**:
+  - Rely on implicit behavior from templates: rejected because it increases adoption friction and support load.
+
+## Baseline and verification notes
+
+- **Baseline render captured**: `helm template gateway ./charts/gateway-api -f ./examples/gateway-api/with-istio-envoyfilter-direct-response.yaml`
+- **Observation**: Templated `httpRoutes[].hostnames` resolve correctly and propagate into generated AuthorizationPolicy and EnvoyFilter resources.
+- **Static regression target**: `helm template base ./charts/base -f ./examples/base/with-istio-gateway-api-http-route-only.yaml`
+
+## Upstream field references checked
+
+- **HTTPRoute hostnames**: [Gateway API HTTPRouteSpec](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec)
+- **AuthorizationPolicy rules**: [Istio AuthorizationPolicy](https://istio.io/latest/docs/reference/config/security/authorization-policy/)
+- **EnvoyFilter configPatches**: [Istio EnvoyFilter](https://istio.io/latest/docs/reference/config/networking/envoy-filter/)

--- a/specs/011-gateway-tpl-support/spec.md
+++ b/specs/011-gateway-tpl-support/spec.md
@@ -1,0 +1,98 @@
+# Feature Specification: Gateway API tpl Support
+
+**Feature Branch**: `011-gateway-tpl-support`  
+**Created**: 2026-04-14  
+**Status**: Draft  
+**Input**: User description: "in dasmeta/helm repo gateway-api we need to add template tpl ability( right now for hostnames) in httproute and istio authorizationpolicy/envoyfilter objects, did already changes in @dasmeta/helm/charts/gateway-api/templates/httproute.yaml:50-51 @dasmeta/helm/charts/gateway-api/templates/istio/envoyfilter.yaml:101-102 @dasmeta/helm/charts/gateway-api/templates/istio/authorizationpolicy.yaml:106-107 and seems all works as expected, did tests with dasmeta/helm/examples/gateway-api/with-istio-envoyfilter-direct-response.yaml, we need also to add specs and do relevant tests/checks and add docs/examples"
+
+## Clarifications
+
+### Session 2026-04-14
+
+- Q: What should the feature version prefix be for this specification and branch? → A: 011.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Render templated route and policy values (Priority: P1)
+
+As a chart consumer, I can provide templated values for HTTPRoute hostnames and Istio policy/filter blocks so one values file can adapt to different release contexts.
+
+**Why this priority**: This is the core behavior change and delivers immediate value for reusable chart configuration.
+
+**Independent Test**: Render the chart with templated values in the target fields and verify rendered manifests contain resolved values for each object.
+
+**Acceptance Scenarios**:
+
+1. **Given** a release values file with templated HTTPRoute hostnames, **When** the chart is rendered, **Then** hostnames are resolved to concrete values in the output manifest.
+2. **Given** a release values file with templated AuthorizationPolicy rules and EnvoyFilter config patches, **When** the chart is rendered, **Then** those blocks are resolved and emitted as valid manifests.
+
+---
+
+### User Story 2 - Preserve existing static behavior (Priority: P2)
+
+As a chart consumer using static values, I can continue rendering manifests without behavioral regression.
+
+**Why this priority**: Backward compatibility is required for existing users and prevents rollout risk.
+
+**Independent Test**: Render existing examples that use static values and verify output remains valid and equivalent for unaffected fields.
+
+**Acceptance Scenarios**:
+
+1. **Given** static values for hostnames, AuthorizationPolicy rules, and EnvoyFilter config patches, **When** the chart is rendered, **Then** output remains valid and consistent with prior behavior.
+
+---
+
+### User Story 3 - Discover and adopt new capability (Priority: P3)
+
+As a chart consumer, I can learn from docs/examples how to supply templated values in the newly supported fields.
+
+**Why this priority**: Documentation and examples make the feature usable without trial-and-error.
+
+**Independent Test**: Follow documented example input and verify the rendered output demonstrates successful templating in each supported field.
+
+**Acceptance Scenarios**:
+
+1. **Given** updated examples and documentation, **When** a user follows the documented pattern, **Then** they can render manifests with templated values in all supported fields on first attempt.
+
+### Edge Cases
+
+- Templated expressions resolve to empty arrays or empty objects; rendering must still produce valid YAML or omit empty sections safely.
+- Template expressions reference missing values; rendering must fail clearly rather than producing silently broken manifests.
+- Mixed static and templated entries are provided in the same list/object; rendering must resolve templates while preserving static entries.
+- Multi-line templated YAML content is used in policy/filter blocks; rendered indentation must remain valid for downstream consumers.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST support templated expressions in HTTPRoute `hostnames` values.
+- **FR-002**: The system MUST support templated expressions in Istio AuthorizationPolicy `rules` values.
+- **FR-003**: The system MUST support templated expressions in Istio EnvoyFilter `configPatches` values.
+- **FR-004**: The system MUST continue to accept and correctly render static (non-templated) values for all existing fields.
+- **FR-005**: The system MUST render valid manifests when templated values resolve successfully.
+- **FR-006**: The system MUST fail with a clear render-time error when templated expressions cannot be resolved.
+- **FR-007**: The project MUST include or update automated checks that validate successful rendering for templated and non-templated cases.
+- **FR-008**: The project MUST include updated user-facing examples showing templated usage for HTTPRoute, AuthorizationPolicy, and EnvoyFilter fields.
+- **FR-009**: The project MUST include documentation updates that explain where templating is supported and how users can verify output.
+
+### Key Entities *(include if feature involves data)*
+
+- **Route hostname configuration**: User-provided list for HTTPRoute host matching that can include static values or template expressions.
+- **Authorization rule configuration**: User-provided policy rules that can include static structures or template expressions.
+- **Filter patch configuration**: User-provided Envoy filter patch definitions that can include static structures or template expressions.
+- **Rendered manifest output**: Final YAML manifests used for deployment and validation by chart consumers.
+
+### Assumptions
+
+- Consumers already use the chart rendering workflow and have access to release context values referenced by templates.
+- Existing example files are the preferred place to demonstrate templating usage for this chart.
+- Existing validation commands/checks can be extended to cover the new scenarios without introducing a new tooling stack.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of provided templated examples for the three supported fields render into valid deployment manifests during project checks.
+- **SC-002**: 100% of existing static-value examples for these objects continue to render successfully after this change.
+- **SC-003**: A chart consumer can configure templated values for all three supported fields and produce expected rendered values in one render attempt.
+- **SC-004**: Documentation and examples for this feature are sufficient for a reviewer unfamiliar with the change to reproduce successful templated rendering in under 15 minutes.

--- a/specs/011-gateway-tpl-support/tasks.md
+++ b/specs/011-gateway-tpl-support/tasks.md
@@ -1,0 +1,190 @@
+# Tasks: Gateway API tpl Support
+
+**Input**: Design documents from `/specs/011-gateway-tpl-support/`  
+**Prerequisites**: `plan.md` (required), `spec.md` (required for user stories), `research.md`, `data-model.md`, `contracts/`, `quickstart.md`
+
+**Tests**: This feature explicitly requires tests/checks. Include `helm lint` plus `helm template` for updated and regression examples.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (`US1`, `US2`, `US3`)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Capture expected object fields, baseline current rendering, and prepare spec-linked implementation context.
+
+- [x] T001 Review and confirm target field contracts in `specs/011-gateway-tpl-support/contracts/render-contract.md` against `charts/gateway-api/templates/httproute.yaml`, `charts/gateway-api/templates/istio/authorizationpolicy.yaml`, and `charts/gateway-api/templates/istio/envoyfilter.yaml`
+- [x] T002 Run baseline render capture for `examples/gateway-api/with-istio-envoyfilter-direct-response.yaml` and record notes in `specs/011-gateway-tpl-support/research.md`
+- [x] T003 [P] Validate official field shape expectations for HTTPRoute hostnames, AuthorizationPolicy rules, and EnvoyFilter configPatches; document references in `specs/011-gateway-tpl-support/research.md`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Ensure shared template behavior and examples command conventions are aligned before story implementation.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [x] T004 Standardize serialized tpl rendering style in `charts/gateway-api/templates/httproute.yaml`, `charts/gateway-api/templates/istio/authorizationpolicy.yaml`, and `charts/gateway-api/templates/istio/envoyfilter.yaml` using `tpl (toYaml ...)` with correct indentation
+- [x] T005 [P] Ensure example command-header comments are present and accurate in `examples/gateway-api/with-istio-envoyfilter-direct-response.yaml` and `examples/base/with-istio-gateway-api-http-route-only.yaml`
+- [x] T006 [P] Align feature docs language for templating capability in `charts/gateway-api/README.md` and `specs/011-gateway-tpl-support/quickstart.md`
+
+**Checkpoint**: Shared templating and documentation foundations are ready for story-by-story delivery.
+
+---
+
+## Phase 3: User Story 1 - Render templated route and policy values (Priority: P1) 🎯 MVP
+
+**Goal**: Support templated values for HTTPRoute hostnames, AuthorizationPolicy rules, and EnvoyFilter config patches.
+
+**Independent Test**: `helm template gateway ./charts/gateway-api -f ./examples/gateway-api/with-istio-envoyfilter-direct-response.yaml` renders resolved values in all three target sections.
+
+### Tests & Checks for User Story 1
+
+- [x] T007 [P] [US1] Run `helm lint` for `./charts/gateway-api` and address template or values issues in `charts/gateway-api/`
+- [x] T008 [US1] Run template verification for `examples/gateway-api/with-istio-envoyfilter-direct-response.yaml` and record expected resolved snippets in `specs/011-gateway-tpl-support/quickstart.md`
+
+### Implementation for User Story 1
+
+- [x] T009 [US1] Implement/confirm tpl rendering for HTTPRoute hostnames in `charts/gateway-api/templates/httproute.yaml`
+- [x] T010 [US1] Implement/confirm tpl rendering for AuthorizationPolicy rules in `charts/gateway-api/templates/istio/authorizationpolicy.yaml`
+- [x] T011 [US1] Implement/confirm tpl rendering for EnvoyFilter config patches in `charts/gateway-api/templates/istio/envoyfilter.yaml`
+- [x] T012 [P] [US1] Update templated example values in `examples/gateway-api/with-istio-envoyfilter-direct-response.yaml` to demonstrate all three supported tpl fields
+- [x] T013 [US1] Update user guidance for supported tpl fields in `charts/gateway-api/README.md`
+
+**Checkpoint**: User Story 1 manifests render with resolved templated values for all required fields.
+
+---
+
+## Phase 4: User Story 2 - Preserve existing static behavior (Priority: P2)
+
+**Goal**: Keep existing static-value behavior unchanged while tpl support is added.
+
+**Independent Test**: Existing static example renders successfully with no regressions in affected objects.
+
+### Tests & Checks for User Story 2
+
+- [x] T014 [US2] Run regression render for `examples/base/with-istio-gateway-api-http-route-only.yaml` against `./charts/base`
+- [x] T015 [P] [US2] Run additional regression render for `examples/gateway-api/minimal.yaml` against `./charts/gateway-api`
+
+### Implementation for User Story 2
+
+- [x] T016 [US2] Adjust template guards/default handling for static values in `charts/gateway-api/templates/httproute.yaml` if regressions are found
+- [x] T017 [US2] Adjust template guards/default handling for static values in `charts/gateway-api/templates/istio/authorizationpolicy.yaml` and `charts/gateway-api/templates/istio/envoyfilter.yaml` if regressions are found
+- [x] T018 [US2] Update regression verification notes in `specs/011-gateway-tpl-support/quickstart.md`
+
+**Checkpoint**: Static examples continue to render successfully after tpl support changes.
+
+---
+
+## Phase 5: User Story 3 - Discover and adopt new capability (Priority: P3)
+
+**Goal**: Provide clear examples/docs so users can apply tpl support without trial-and-error.
+
+**Independent Test**: A reviewer follows docs/examples and renders expected manifests within one pass.
+
+### Tests & Checks for User Story 3
+
+- [x] T019 [US3] Validate documented commands in `charts/gateway-api/README.md` and `examples/gateway-api/with-istio-envoyfilter-direct-response.yaml` execute successfully as written
+
+### Implementation for User Story 3
+
+- [x] T020 [US3] Expand `charts/gateway-api/README.md` with explicit tpl-support notes and field-specific examples for hostnames, rules, and config patches
+- [x] T021 [P] [US3] Update `specs/011-gateway-tpl-support/quickstart.md` with a concise “how to verify resolved output” checklist
+- [x] T022 [US3] Ensure example commentary in `examples/gateway-api/with-istio-envoyfilter-direct-response.yaml` clearly identifies tpl-driven values
+
+**Checkpoint**: Documentation and examples are clear enough for first-attempt success.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final compliance, versioning, and release-readiness checks across all stories.
+
+- [x] T023 [P] Run final `helm lint ./charts/gateway-api` and final template renders for updated/regression examples from `specs/011-gateway-tpl-support/quickstart.md`
+- [x] T024 Update `charts/gateway-api/Chart.yaml` version (semver patch or higher) for chart template/doc/example behavior change
+- [x] T025 Update `charts/base/Chart.yaml` version (semver patch or higher) if base chart/example-linked behavior changed in this feature
+- [x] T026 Re-run all quickstart verification commands from `specs/011-gateway-tpl-support/quickstart.md` and capture final pass notes in `specs/011-gateway-tpl-support/research.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies; starts immediately.
+- **Phase 2 (Foundational)**: Depends on Phase 1; blocks all user stories.
+- **Phase 3 (US1)**: Depends on Phase 2; MVP delivery phase.
+- **Phase 4 (US2)**: Depends on Phase 3 completion to validate non-regression of final US1 behavior.
+- **Phase 5 (US3)**: Depends on stable US1/US2 outputs for accurate documentation.
+- **Phase 6 (Polish)**: Depends on all user story phases.
+
+### User Story Dependencies
+
+- **US1 (P1)**: No dependency on other stories after Foundational.
+- **US2 (P2)**: Depends on US1 implementation presence to validate static non-regression against changed templates.
+- **US3 (P3)**: Depends on US1/US2 finalized behavior for accurate docs/examples.
+
+### Within Each User Story
+
+- Run checks first, then apply/adjust implementation, then re-run verification.
+- Keep template edits scoped to their target files to minimize cross-story coupling.
+
+### Parallel Opportunities
+
+- `T003`, `T005`, `T006` can run in parallel in early phases.
+- `T007` and `T012` can run in parallel after template edits are drafted.
+- `T014` and `T015` can run in parallel for regression coverage.
+- `T021` can run in parallel with `T020` once behavior is finalized.
+- `T023` can run in parallel with release-note preparation while waiting for version bumps.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Parallel checks and example prep for US1:
+Task: "T007 [US1] Run helm lint for ./charts/gateway-api"
+Task: "T012 [US1] Update templated example values in examples/gateway-api/with-istio-envoyfilter-direct-response.yaml"
+
+# Then sequential template implementation:
+Task: "T009 [US1] Update httproute tpl rendering"
+Task: "T010 [US1] Update authorizationpolicy tpl rendering"
+Task: "T011 [US1] Update envoyfilter tpl rendering"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 and Phase 2.
+2. Complete US1 (`T007`-`T013`).
+3. Validate the US1 independent test command.
+4. Demo/verify resolved output snippets.
+
+### Incremental Delivery
+
+1. Deliver US1 (tpl capability).
+2. Deliver US2 (non-regression on static values).
+3. Deliver US3 (docs/examples adoption clarity).
+4. Run final polish checks and version bumps.
+
+### Parallel Team Strategy
+
+1. One engineer handles template logic (`T009`-`T011`).
+2. One engineer handles examples/docs (`T012`, `T013`, `T020`, `T022`).
+3. One engineer handles verification passes (`T007`, `T014`, `T015`, `T023`, `T026`).
+
+---
+
+## Notes
+
+- All tasks use explicit file paths and execution order.
+- Version bump tasks are explicitly included for chart compliance.
+- Keep commits scoped by phase or by completed user-story checkpoint.


### PR DESCRIPTION
### Summary
Adds DMVP-9224 support for templated values in Gateway API route and Istio policy/filter configuration fields, with updated chart docs, runnable examples, and full Speckit planning artifacts for implementation traceability.
### Key Changes
- Added Helm `tpl` rendering support for `httpRoutes[].hostnames` in `charts/gateway-api/templates/httproute.yaml`.
- Added Helm `tpl` rendering support for AuthorizationPolicy `rules` in `charts/gateway-api/templates/istio/authorizationpolicy.yaml`.
- Added Helm `tpl` rendering support for EnvoyFilter `configPatches` in `charts/gateway-api/templates/istio/envoyfilter.yaml`.
- Bumped `gateway-api` chart version in `charts/gateway-api/Chart.yaml`.
- Updated `charts/gateway-api/README.md` to document templating support for hostname/rules/config patches.
- Updated `examples/gateway-api/with-istio-envoyfilter-direct-response.yaml` with templated usage additions.
- Added new example `examples/gateway-api/with-template-hostname.yaml` to demonstrate template-driven hostnames.
- Added feature specification at `specs/011-gateway-tpl-support/spec.md`.
- Added implementation plan at `specs/011-gateway-tpl-support/plan.md`.
- Added task breakdown at `specs/011-gateway-tpl-support/tasks.md`.
- Added supporting artifacts: `research.md`, `data-model.md`, `contracts/render-contract.md`, `quickstart.md`.
- Added requirements checklist at `specs/011-gateway-tpl-support/checklists/requirements.md`.