### PR TITLE
fix(DMVP-9224): support templates injection in httproute routes configs

### DIFF
--- a/charts/gateway-api/Chart.yaml
+++ b/charts/gateway-api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gateway-api/templates/httproute.yaml
+++ b/charts/gateway-api/templates/httproute.yaml
@@ -120,7 +120,7 @@ spec:
         {{- $_ := set $rule "backendRefs" $processedBackendRefs }}
       {{- end }}
       {{- if or $rule.matches $rule.filters $rule.backendRefs }}
-        {{- toYaml (list $rule) | nindent 4 | trimPrefix "- " }}
+        {{- tpl (toYaml (list $rule)) $outer | nindent 4 | trimPrefix "- " }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/examples/gateway-api/with-template-hostname.yaml
+++ b/examples/gateway-api/with-template-hostname.yaml
@@ -39,5 +39,5 @@ httpRoutes:
               type: PathPrefix
               value: /
         backendRefs:
-          - name: api-v1
+          - name: "{{ .Values.global.environment }}.api-v1"
             port: 80


### PR DESCRIPTION
## Summary
This commit enables template evaluation inside `httpRoutes` rule rendering in the `gateway-api` chart, so route fields can reference chart values (e.g., environment-specific backend names). It also updates the related example and bumps the chart version.
### Key Changes
- Bumped `charts/gateway-api/Chart.yaml` version from `0.1.6` to `0.1.7`.
- Updated `charts/gateway-api/templates/httproute.yaml` to render route rule YAML through `tpl`, enabling value/template injection in route config fields.
- Updated `examples/gateway-api/with-template-hostname.yaml` to demonstrate templated backend service naming:
  - `backendRefs[].name: "{{ .Values.global.environment }}.api-v1"`.
### Testing/Verification
- Verified commit content via latest commit diff (`git show -1`) and file-level patch review.
