### PR TITLE
feat(base): support HPA->ScaledObject migration via transfer-hpa-ownership annotation

### DIFF
--- a/charts/base/Chart.yaml
+++ b/charts/base/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.28
+version: 0.3.29
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.28"
+appVersion: "0.3.29"
 
 dependencies:
   - name: gateway-api

--- a/charts/base/README.md
+++ b/charts/base/README.md
@@ -645,6 +645,68 @@ autoscaling:
       awsRegion: <aws-region>
 ```
 
+### Migrating from plain HPA to KEDA without deleting the existing HPA
+
+When this chart is rendered with `autoscaling.enabled: true` and no `trigger`/`triggers`,
+it produces a plain `HorizontalPodAutoscaler` named `{{ include "base.fullname" . }}`.
+When `triggers` is set, the same template path produces a KEDA `ScaledObject` with the
+same name. Flipping a release between the two modes via `helm upgrade` is rejected by
+KEDA's `vscaledobject.kb.io` admission webhook because the same-named HPA still exists
+when the new ScaledObject is created (Helm creates new resources before deleting old
+ones during upgrade). See [kedacore/keda#6250](https://github.com/kedacore/keda/issues/6250)
+for background.
+
+The chart now exposes the two fields KEDA's
+[transfer-hpa-ownership](https://keda.sh/docs/2.19/concepts/scaling-deployments/#transfer-ownership-of-an-existing-hpa)
+migration path needs:
+
+```yaml
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 50
+  scaledObjectAnnotations:
+    scaledobject.keda.sh/transfer-hpa-ownership: "true"
+  hpaName: my-release-name # must match the existing HPA's metadata.name
+  triggers:
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: "70"
+```
+
+With the annotation, the webhook skips its duplicate-HPA check, and KEDA claims the
+existing HPA in place by rewriting its `ownerReferences`.
+
+There is one residual subtlety: Helm still deletes the old HPA at the end of the
+upgrade (because the chart no longer renders an HPA template when `triggers` is set),
+which leaves a brief metrics-blind window of up to `pollingInterval` seconds before
+KEDA's reconciler recreates the HPA. The deployment's replica count stays put during
+this window because Kubernetes does not autoscale a Deployment without an autoscaler;
+only metrics evaluation pauses.
+
+For a zero-gap migration, also tell Helm to keep the old HPA before the upgrade:
+
+```bash
+kubectl annotate hpa/<existing-hpa-name> -n <namespace> helm.sh/resource-policy=keep
+helm upgrade <release> dasmeta/base --version <new-version> -f values.yaml
+```
+
+After the upgrade has completed and KEDA owns the HPA, you can remove the annotation:
+
+```bash
+kubectl annotate hpa/<existing-hpa-name> -n <namespace> helm.sh/resource-policy-
+```
+
+#### Reverse direction (KEDA → plain HPA)
+
+There is no equivalent transfer mechanism for going back from a `ScaledObject` to a
+plain HPA via this chart. KEDA owns its managed HPA via `ownerReferences`, so deleting
+the `ScaledObject` triggers garbage collection of the underlying HPA. Tracking issue:
+[kedacore/keda#6250](https://github.com/kedacore/keda/issues/6250). If you need to
+reverse, expect to manually recreate the HPA after the chart upgrade has removed the
+ScaledObject.
+
 ### custom rollout strategy(canary,blue/gree) configs by using flagger
 ```yaml
 # This config allows to enable custom rollout strategies by using different providers/operators

--- a/charts/base/templates/keda.yaml
+++ b/charts/base/templates/keda.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "base.fullname" . }}
   labels:
     {{- include "base.labels" . | nindent 4 }}
+  {{- with .Values.autoscaling.scaledObjectAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     name: {{ include "base.fullname" . }}
@@ -42,10 +46,15 @@ spec:
         {{ $key }}: "{{ $value }}"
         {{- end }}
     {{- end }}
-  {{- if .Values.autoscaling.behavior }}
+  {{- if or .Values.autoscaling.behavior .Values.autoscaling.hpaName }}
   advanced:
     horizontalPodAutoscalerConfig:
+      {{- with .Values.autoscaling.hpaName }}
+      name: {{ . }}
+      {{- end }}
+      {{- with .Values.autoscaling.behavior }}
       behavior:
-{{ toYaml .Values.autoscaling.behavior | nindent 8 }}
+{{ toYaml . | nindent 8 }}
+      {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/base/values.yaml
+++ b/charts/base/values.yaml
@@ -240,6 +240,16 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
 
+  # Optional. Annotations to apply to the rendered ScaledObject (KEDA mode only).
+  # Useful for KEDA's transfer-hpa-ownership migration path.
+  # scaledObjectAnnotations:
+  #   scaledobject.keda.sh/transfer-hpa-ownership: "true"
+
+  # Optional. Custom name for the HPA that KEDA manages on behalf of the ScaledObject.
+  # Defaults to "keda-hpa-{release-name}". Set to the existing HPA's name when migrating
+  # from plain HPA to KEDA via transfer-hpa-ownership (see README).
+  # hpaName: my-existing-hpa
+
   # Optional HPA scale up/down behavior (Kubernetes autoscaling/v2+).
   # If set, it will be rendered under `spec.behavior` in the generated HPA.
   #
@@ -313,6 +323,25 @@ autoscaling:
 #       metadata:
 #         queueName: my-queue
 #         queueLength: "50"
+
+# Example: Migrate an existing plain HPA to a KEDA ScaledObject without manually
+# deleting the old HPA. KEDA's vscaledobject.kb.io webhook normally rejects creating
+# a ScaledObject when an HPA already manages the same workload; the transfer-hpa-ownership
+# annotation, paired with `hpaName` matching the existing HPA's name, tells KEDA to
+# claim the existing HPA in place. See charts/base/README.md for the full recipe
+# (including the optional `helm.sh/resource-policy: keep` step for zero-gap migration).
+# autoscaling:
+#   enabled: true
+#   minReplicas: 2
+#   maxReplicas: 50
+#   scaledObjectAnnotations:
+#     scaledobject.keda.sh/transfer-hpa-ownership: "true"
+#   hpaName: my-release-name # must match the existing HPA's metadata.name
+#   triggers:
+#     - type: cpu
+#       metricType: Utilization
+#       metadata:
+#         value: "70"
 
 nodeSelector: {}
 


### PR DESCRIPTION
## Summary

Adds two backward-compatible passthroughs to the KEDA `ScaledObject` template in the `base` chart so consumers can use KEDA's [`transfer-hpa-ownership`](https://keda.sh/docs/2.19/concepts/scaling-deployments/#transfer-ownership-of-an-existing-hpa) migration path without forking the chart:

1. **`autoscaling.scaledObjectAnnotations`** (map) — rendered as `metadata.annotations` on the ScaledObject.
2. **`autoscaling.hpaName`** (string) — rendered as `advanced.horizontalPodAutoscalerConfig.name`. Combined with the existing `behavior` block under a single `advanced` clause guarded by `or` of the two values.

Also adds a "Migrating from plain HPA to KEDA" section to `charts/base/README.md` documenting the full recipe.

## Motivation

The chart already commits to a dual-mode design where `templates/hpa.yaml` (when `autoscaling.triggers` is unset) and `templates/keda.yaml` (when set) are mutually exclusive and both render a resource named `{{ include "base.fullname" . }}`. Flipping a release between the two via `helm upgrade` is rejected by KEDA's `vscaledobject.kb.io` admission webhook because the same-named HPA still exists when the new ScaledObject is created (Helm creates new resources before deleting old ones during upgrade):

```
Error: UPGRADE FAILED: failed to create resource: admission webhook "vscaledobject.kb.io"
denied the request: the workload '<name>' of type 'apps/v1.Deployment' is already
managed by the hpa '<name>'
```

KEDA's documented migration path is the [`scaledobject.keda.sh/transfer-hpa-ownership: "true"`](https://keda.sh/docs/2.19/concepts/scaling-deployments/#transfer-ownership-of-an-existing-hpa) annotation paired with `advanced.horizontalPodAutoscalerConfig.name` matching the existing HPA. Today's chart exposes neither, so a chart consumer hitting this has to either fork the chart, use a post-renderer, or `kubectl delete hpa <name>` before the upgrade (which leaves a brief window with no autoscaler at all). See [kedacore/keda#6250](https://github.com/kedacore/keda/issues/6250) for the broader context on why this is awkward by default.

This PR finishes the dual-mode design the chart already started.

## Changes

### `charts/base/templates/keda.yaml`

- Add `metadata.annotations` block guarded by `with .Values.autoscaling.scaledObjectAnnotations`.
- Combine `advanced.horizontalPodAutoscalerConfig.name` with the existing `behavior` block under a single `advanced` clause guarded by `or .Values.autoscaling.behavior .Values.autoscaling.hpaName`. Each child field uses `with` so it only renders when set.

### `charts/base/values.yaml`

- Add commented-out `scaledObjectAnnotations` and `hpaName` examples in the `autoscaling:` section with inline guidance.
- Add a full "Migrate plain HPA to KEDA" example block alongside the existing trigger examples.

### `charts/base/README.md`

- Add "Migrating from plain HPA to KEDA without deleting the existing HPA" section with the full recipe (chart values + optional `kubectl annotate hpa/<name> helm.sh/resource-policy=keep` for zero-gap migration), the residual ~30s metrics-blind window note (Helm deletes the old HPA at end of upgrade; KEDA recreates it on next reconcile), and the reverse-direction caveat.

### `charts/base/Chart.yaml`

- Bump `version` and `appVersion` from `0.3.28` to `0.3.29`.

## Backward Compatibility

- **Existing HPA-only users** (`autoscaling.enabled: true`, no `trigger`/`triggers`): zero changes — HPA still renders, no ScaledObject.
- **Existing single-trigger KEDA users** (`autoscaling.trigger`): zero changes — singular trigger path is untouched.
- **Existing multi-trigger KEDA users** (`autoscaling.triggers`, possibly with `behavior`): zero changes — the new `with .Values.autoscaling.hpaName` is conditionally rendered only when the new field is set, and the existing `behavior` block is wrapped in its own `with` to remain unchanged.
- **New `scaledObjectAnnotations`/`hpaName`**: fully opt-in.

## Example Usage

Migrate an existing plain HPA named `my-release-name` to a KEDA ScaledObject without manually deleting the HPA:

```yaml
autoscaling:
  enabled: true
  minReplicas: 2
  maxReplicas: 50
  scaledObjectAnnotations:
    scaledobject.keda.sh/transfer-hpa-ownership: "true"
  hpaName: my-release-name # must match the existing HPA's metadata.name
  triggers:
    - type: cpu
      metricType: Utilization
      metadata:
        value: "70"
```

For zero metrics-blind window during the transition, also pre-annotate the existing HPA so Helm leaves it alone during the upgrade:

```bash
kubectl annotate hpa/my-release-name -n <ns> helm.sh/resource-policy=keep
helm upgrade <release> dasmeta/base --version 0.3.29 -f values.yaml
kubectl annotate hpa/my-release-name -n <ns> helm.sh/resource-policy- # cleanup post-upgrade
```

## Validation

- `helm lint charts/base` — passes clean.
- `helm template charts/base --values <file>` smoke tests:
  - **Old HPA-only** (`autoscaling.enabled: true`, no triggers, with `behavior`): renders an HPA, no ScaledObject, no annotations. Byte-for-byte identical to pre-change template output (only the chart-version label moves `0.3.28` → `0.3.29`).
  - **Old multi-trigger KEDA** (existing `triggers` array + `behavior`, no new fields): renders ScaledObject with no annotations and no `advanced.horizontalPodAutoscalerConfig.name`. Byte-for-byte identical to pre-change output (only chart-version label change).
  - **New transfer-ownership** (`scaledObjectAnnotations` + `hpaName` set): renders ScaledObject with `metadata.annotations.scaledobject.keda.sh/transfer-hpa-ownership: "true"` and `advanced.horizontalPodAutoscalerConfig.name: my-existing-hpa`. No `behavior` block (correctly omitted when not set).
  - **`hpaName` + `behavior` combo**: both render correctly nested under a single `advanced.horizontalPodAutoscalerConfig` block.
- `pre-commit run --all-files` — all hooks pass (including helmlint, gitleaks, conventional-commits).